### PR TITLE
Fix the errors in iOS Safari and prevent infinite recursion when there is no scrolling to do

### DIFF
--- a/ie11-scroll-into-view.js
+++ b/ie11-scroll-into-view.js
@@ -1,98 +1,98 @@
 (function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
-  } else if (typeof module === 'object' && module.exports) {
-    // Node. Does not work with strict CommonJS, but
-    // only CommonJS-like environments that support module.exports,
-    // like Node.
-    module.exports = factory(require('jquery'));
-  } else {
-    // Browser globals (root is window)
-    root.ie11ScrollIntoView = factory(root.jQuery);
-  }
-}(this, function ($) {
-  'use strict';
-  function detectIE11() {
-    return window.navigator.userAgent.indexOf('Trident/') > 0;
-  }
-
-  // Return early if this isn't IE 11
-
-  if (!detectIE11()) return;
-
-  // hasScroller - snippet from StackOverflow:
-  // http://stackoverflow.com/a/34700876
-  var hasScroller = (function () {
-    var getComputedStyle = document.body && document.body.currentStyle ? function (elem) {
-      return elem.currentStyle;
-    } : function (elem) {
-      return document.defaultView.getComputedStyle(elem, null);
-    };
-
-    function getActualCss(elem, style) {
-      return getComputedStyle(elem)[style];
-    }
-
-    function autoOrScroll(text) {
-      return text === 'scroll' || text === 'auto';
-    }
-
-    function isXScrollable(elem) {
-      return elem.offsetWidth < elem.scrollWidth &&
-        autoOrScroll(getActualCss(elem, 'overflow-x'));
-    }
-
-    function isYScrollable(elem) {
-      return elem.offsetHeight < elem.scrollHeight &&
-        autoOrScroll(getActualCss(elem, 'overflow-y'));
-    }
-
-    return function (elem) {
-      return isYScrollable(elem) || isXScrollable(elem);
-    };
-  })();
-
-  // One of the element's parents is hopefully a scroller
-  function recursiveFindClosestScroller(el) {
-    if (hasScroller(el)) {
-      return el;
-    }
-
-    if (el.parentNode === null) {
-      return null;
-    }
-
-    return recursiveFindClosestScroller(el.parentNode);
-  }
-
-  function ieScrollIntoView(el) {
-    var scrollContainer = recursiveFindClosestScroller(el)
-      , $scrollContainer
-      , $el
-      , gridMainScrollTop
-      , elOffsetTop
-      , gridMainTop
-      ;
-    if (scrollContainer === null) {
-      // We couldn't find a scroll container.
-      // This is probably because no scrolling is needed, so do nothing.
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['jquery'], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory(require('jquery'));
     } else {
-      $scrollContainer  = $(scrollContainer);
-      $el               = $(el);
-      gridMainScrollTop = $scrollContainer.scrollTop();
-      elOffsetTop       = $el.offset().top;
-      gridMainTop       = $scrollContainer.offset().top;
-
-      $scrollContainer.scrollTop(
-        gridMainScrollTop + elOffsetTop - gridMainTop
-      );
+        // Browser globals (root is window)
+        root.ie11ScrollIntoView = factory(root.jQuery);
     }
-  }
+}(this, function ($) {
+    'use strict';
+    function detectIE11() {
+        return window.navigator.userAgent.indexOf('Trident/') > 0;
+    }
 
-  HTMLElement.prototype.scrollIntoView = function () {
-    ieScrollIntoView(this);
-  };
+    // Return early if this isn't IE 11
 
-  return {};
+    if (!detectIE11()) return;
+
+    // hasScroller - snippet from StackOverflow:
+    // http://stackoverflow.com/a/34700876
+    var hasScroller = (function () {
+        var getComputedStyle = document.body && document.body.currentStyle ? function (elem) {
+            return elem.currentStyle;
+        } : function (elem) {
+            return document.defaultView.getComputedStyle(elem, null);
+        };
+
+        function getActualCss(elem, style) {
+            return getComputedStyle(elem)[style];
+        }
+
+        function autoOrScroll(text) {
+            return text === 'scroll' || text === 'auto';
+        }
+
+        function isXScrollable(elem) {
+            return elem.offsetWidth < elem.scrollWidth &&
+                autoOrScroll(getActualCss(elem, 'overflow-x'));
+        }
+
+        function isYScrollable(elem) {
+            return elem.offsetHeight < elem.scrollHeight &&
+                autoOrScroll(getActualCss(elem, 'overflow-y'));
+        }
+
+        return function (elem) {
+            return isYScrollable(elem) || isXScrollable(elem);
+        };
+    })();
+
+    // One of the element's parents is hopefully a scroller
+    function recursiveFindClosestScroller(el) {
+        if (hasScroller(el)) {
+            return el;
+        }
+
+        if (el.parentNode === null) {
+            return null;
+        }
+
+        return recursiveFindClosestScroller(el.parentNode);
+    }
+
+    function ieScrollIntoView(el) {
+        var scrollContainer = recursiveFindClosestScroller(el)
+            , $scrollContainer
+            , $el
+            , gridMainScrollTop
+            , elOffsetTop
+            , gridMainTop
+            ;
+        if (scrollContainer === null) {
+            // We couldn't find a scroll container.
+            // This is probably because no scrolling is needed, so do nothing.
+        } else {
+            $scrollContainer  = $(scrollContainer);
+            $el               = $(el);
+            gridMainScrollTop = $scrollContainer.scrollTop();
+            elOffsetTop       = $el.offset().top;
+            gridMainTop       = $scrollContainer.offset().top;
+
+            $scrollContainer.scrollTop(
+                gridMainScrollTop + elOffsetTop - gridMainTop
+            );
+        }
+    }
+
+    HTMLElement.prototype.scrollIntoView = function () {
+        ieScrollIntoView(this);
+    };
+
+    return {};
 }));

--- a/ie11-scroll-into-view.js
+++ b/ie11-scroll-into-view.js
@@ -1,101 +1,98 @@
 (function (root, factory) {
-    if (typeof define === 'function' && define.amd) {
-        // AMD. Register as an anonymous module.
-        define(['jquery'], factory);
-    } else if (typeof module === 'object' && module.exports) {
-        // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like environments that support module.exports,
-        // like Node.
-        module.exports = factory(require('jquery'));
-    } else {
-        // Browser globals (root is window)
-        root.ie11ScrollIntoView = factory(root.jQuery);
-    }
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory(require('jquery'));
+  } else {
+    // Browser globals (root is window)
+    root.ie11ScrollIntoView = factory(root.jQuery);
+  }
 }(this, function ($) {
-    'use strict';
-    function detectIE11 () {
-        return window.navigator.userAgent.indexOf('Trident/') > 0;
+  'use strict';
+  function detectIE11() {
+    return window.navigator.userAgent.indexOf('Trident/') > 0;
+  }
+
+  // Return early if this isn't IE 11
+
+  if (!detectIE11()) return;
+
+  // hasScroller - snippet from StackOverflow:
+  // http://stackoverflow.com/a/34700876
+  var hasScroller = (function () {
+    var getComputedStyle = document.body && document.body.currentStyle ? function (elem) {
+      return elem.currentStyle;
+    } : function (elem) {
+      return document.defaultView.getComputedStyle(elem, null);
+    };
+
+    function getActualCss(elem, style) {
+      return getComputedStyle(elem)[style];
     }
 
-    // Disable no-inner-declations check; we really, really don't want
-    // to run any of the code unless it's IE 11.
-    /* eslint-disable no-inner-declarations */
-
-    // Return early if this isn't IE 11
-    if (detectIE11()) {
-        // hasScroller - snippet from StackOverflow:
-        // http://stackoverflow.com/a/34700876
-        var hasScroller = (function () {
-            var getComputedStyle = document.body && document.body.currentStyle ? function (elem) {
-                return elem.currentStyle;
-            } : function (elem) {
-                return document.defaultView.getComputedStyle(elem, null);
-            };
-
-            function getActualCss (elem, style) {
-                return getComputedStyle(elem)[style];
-            }
-
-            function autoOrScroll (text) {
-                return text === 'scroll' || text === 'auto';
-            }
-
-            function isXScrollable (elem) {
-                return elem.offsetWidth < elem.scrollWidth &&
-                    autoOrScroll(getActualCss(elem, 'overflow-x'));
-            }
-
-            function isYScrollable (elem) {
-                return elem.offsetHeight < elem.scrollHeight &&
-                    autoOrScroll(getActualCss(elem, 'overflow-y'));
-            }
-
-            return function (elem) {
-                return isYScrollable(elem) || isXScrollable(elem);
-            };
-        })();
-
-        // One of the element's parents is hopefully a scroller
-        function recursiveFindClosestScroller (el) {
-            if (hasScroller(el)) {
-                return el;
-            }
-
-            if (el.parentNode === null) {
-                return null;
-            }
-
-            return recursiveFindClosestScroller(el.parentNode);
-        }
-
-        function ieScrollIntoView (el) {
-            var scrollContainer = recursiveFindClosestScroller(el)
-                , $scrollContainer
-                , $el
-                , gridMainScrollTop
-                , elOffsetTop
-                , gridMainTop
-                ;
-            if (scrollContainer === null) {
-                // We couldn't find a scroll container, so let's fall
-                // back to using scrollIntoView for now (and hope for the best)
-                el.scrollIntoView();
-            } else {
-                $scrollContainer = $(scrollContainer);
-                $el = $(el);
-                gridMainScrollTop = $scrollContainer.scrollTop();
-                elOffsetTop = $el.offset().top;
-                gridMainTop = $scrollContainer.offset().top;
-
-                $scrollContainer.scrollTop(
-                    gridMainScrollTop + elOffsetTop - gridMainTop
-                );
-            }
-        }
-
-        HTMLElement.prototype.scrollIntoView = function () {
-            ieScrollIntoView(this);
-        };
+    function autoOrScroll(text) {
+      return text === 'scroll' || text === 'auto';
     }
-    return {};
+
+    function isXScrollable(elem) {
+      return elem.offsetWidth < elem.scrollWidth &&
+        autoOrScroll(getActualCss(elem, 'overflow-x'));
+    }
+
+    function isYScrollable(elem) {
+      return elem.offsetHeight < elem.scrollHeight &&
+        autoOrScroll(getActualCss(elem, 'overflow-y'));
+    }
+
+    return function (elem) {
+      return isYScrollable(elem) || isXScrollable(elem);
+    };
+  })();
+
+  // One of the element's parents is hopefully a scroller
+  function recursiveFindClosestScroller(el) {
+    if (hasScroller(el)) {
+      return el;
+    }
+
+    if (el.parentNode === null) {
+      return null;
+    }
+
+    return recursiveFindClosestScroller(el.parentNode);
+  }
+
+  function ieScrollIntoView(el) {
+    var scrollContainer = recursiveFindClosestScroller(el)
+      , $scrollContainer
+      , $el
+      , gridMainScrollTop
+      , elOffsetTop
+      , gridMainTop
+      ;
+    if (scrollContainer === null) {
+      // We couldn't find a scroll container.
+      // This is probably because no scrolling is needed, so do nothing.
+    } else {
+      $scrollContainer  = $(scrollContainer);
+      $el               = $(el);
+      gridMainScrollTop = $scrollContainer.scrollTop();
+      elOffsetTop       = $el.offset().top;
+      gridMainTop       = $scrollContainer.offset().top;
+
+      $scrollContainer.scrollTop(
+        gridMainScrollTop + elOffsetTop - gridMainTop
+      );
+    }
+  }
+
+  HTMLElement.prototype.scrollIntoView = function () {
+    ieScrollIntoView(this);
+  };
+
+  return {};
 }));

--- a/index.html
+++ b/index.html
@@ -109,6 +109,20 @@
 </div>
 </div>
 </div>
+<div class="sections">
+  <div class="section">
+    <div class="overflow-scroll">
+      <ol>
+        <li id="first-baz">Baz</li>
+        <li id="last-baz">Baz</li>
+      </ol>
+    </div>
+    <div class="buttons">
+      <button data-section="baz" data-to="first">Scroll to top</button>
+      <button data-section="baz" data-to="last">Scroll to bottom</button>
+    </div>
+  </div>
+</div>
 <script>
     function getWrapperScrollLeft() {
         return document.getElementById('horizontal-scroller').scrollLeft;
@@ -120,13 +134,18 @@
 
             var to = button.getAttribute('data-to') + '-' + button.getAttribute('data-section');
             console.log('Jump to', to);
+            var timeout=setTimeout(function(){
+                document.getElementById('message').innerHTML =
+                    '<p class="message-error">Test failed: scrollIntoView has taken more than 2 seconds.</p>';
+            },2000);
             document.getElementById(to).scrollIntoView();
+            clearTimeout(timeout);
 
             var scrollLeftAfter = getWrapperScrollLeft();
 
             if (scrollLeftBefore === scrollLeftAfter) {
                 document.getElementById('message').innerHTML =
-                        '<p class="message-ok">Test passed: Behavior of scrollIntoView was like expected.</p>';
+                        '<p class="message-ok">Test passed: Behavior of scrollIntoView was as expected.</p>';
             } else {
                 document.getElementById('message').innerHTML =
                         '<p class="message-error">Test failed: the browser scrolled horizontally.</p>';


### PR DESCRIPTION
This pull request fixes two things.

The first is to move all of the function declarations to be in the top level block of the function or global scope.  JS standards state that functions should only be declared at the top level of a function or the global scope and while most browsers seem to be tolerant to this it turns out that iOS safari is not.

The second was solve an infinite recursion problem.  Previously if scrollIntoView was called when there was nothing overflowing (e.g. a application calls it automatically regardless if it is required or not) then it could not find a 'scroll container' and then called scrollIntoView again.  THe intention was clearly to call the OLD version, however what it did was call itself where it would repeat the same checks and call itself again, and so on in an infinite recursive loop.  So first I've added a test for this in the html (a very short 'baz' list).  The fix I've implemented is to do nothing if no scroll container was found because calling the old version was still causing problems in out application and as far as I could tell the only time no scroll container is found is when there is no scrolling to be done.